### PR TITLE
fix: typo landing page

### DIFF
--- a/src/screens/LandingPage/LandingPage.js
+++ b/src/screens/LandingPage/LandingPage.js
@@ -11,7 +11,7 @@ function LandingPage() {
         <Row>
           <div className="intro-text">
             <div>
-              <h1 className="title">Welcome to Note Zipperrrr </h1>
+              <h1 className="title">Welcome to Note Zipper </h1>
               <p className="subtitle">One Safe place for all your notes.</p>
             </div>
             <div className="buttonContainer">


### PR DESCRIPTION
fixes: #1 

#Changed Spelling to Zipper.

Screenshot
![image](https://github.com/Govagit007/client-zipper/assets/135409133/c39cefb4-df60-4723-a8a3-2897e49b9d46)
